### PR TITLE
Refactor OrdersController and clean up routes

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,8 +2,8 @@ class OrdersController < ApplicationController
   include CurrentOrder
 
   before_action :authenticate_user!
-  before_action :set_order, only: [:confirm_order, :update_status]
-  before_action :authorize_admin, only: [:index, :update_status]
+  before_action :set_order, only: [:confirm_order, :update]
+  before_action :authorize_admin, only: [:index, :update]
   #
   def index
     # The status parameter is expected to come from the URL query string
@@ -19,6 +19,8 @@ class OrdersController < ApplicationController
     @orders = @orders.order(created_at: :desc)
   end
 
+  ## this confirm_order action is actually for the user to confirm their order
+  ## it only changes the status of the order from created to pending
   def confirm_order
     if @order.created? && @order.update(status: :pending)
       redirect_to checkout_path, notice: "Order confirmed!"
@@ -27,7 +29,7 @@ class OrdersController < ApplicationController
     end
   end
 
-  def update_status
+  def update
     if @order.update(order_params)
       redirect_to orders_path, notice: 'Order status was successfully updated.'
     else

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,7 +5,7 @@
     <% end %>
     <div class="navbar-nav ms-auto f-flex align-items-center justify-content-between">
       <% if current_user.role == "admin" %>
-          <%= link_to "+ product", new_product_path, class: "btn btn-success me-2"%>
+          <%= link_to "+ Product", new_product_path, class: "btn btn-success me-2"%>
           <%= link_to "Orders", orders_path, class: "btn btn-info me-3"%>
       <% else %>
         <%= link_to cart_path, class: "nav-link me-3" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Rails.application.routes.draw do
   resources :orders do
     member do
       patch 'confirm_order'
-      patch 'update_status'
     end
     collection do
       get 'pending_orders'


### PR DESCRIPTION
- Refactor `OrdersController`:
  - Rename `update_status` action to `update` to follow RESTful conventions.
  - Adjust `before_action` filters to reflect the changes in action names.
  - Clarify `confirm_order` action purpose with comments, indicating it's for users to confirm their orders.

- Update views:
  - Correct capitalization in the navbar link from "+ product" to "+ Product" for consistency.

- Clean up routes:
  - Remove the `update_status` route as it is now covered by the standard `update` action.

These changes improve code clarity, follow RESTful conventions, and clean up the UI for better usability.